### PR TITLE
Slurm launcher configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,6 @@ dmypy.json
 # PyCharm
 .idea
 
-# PyTorch Lightning
+# Logs and checkpoints
+logs/
 lightning_logs/
-
-# Hydra
-outputs/

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -6,9 +6,10 @@ defaults:
 seed: 1501
 
 trainer:
-  max_epochs: 10
+  num_nodes: 1
   gpus: 2
-  accelerator: ddp
+  accelerator: ddp_spawn
+  max_epochs: 10
 
 callbacks:
   - _target_: pytorch_lightning.callbacks.LearningRateMonitor
@@ -20,3 +21,16 @@ callbacks:
 
 dataset:
   root: /private/home/viswanath/emg2qwerty-data-2021-06-24
+
+hydra:
+  run:
+    dir: logs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: logs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}_${hydra.job.override_dirname}
+  job:
+    name: emg2qwerty
+    config:
+      override_dirname:
+        exclude_keys:
+          - cluster

--- a/config/cluster/local.yaml
+++ b/config/cluster/local.yaml
@@ -1,0 +1,9 @@
+# @package _global_
+defaults:
+  - override /hydra/launcher: submitit_local
+
+hydra:
+  launcher:
+    nodes: ${trainer.num_nodes}
+    gpus_per_node: ${trainer.gpus}
+    tasks_per_node: 1

--- a/config/cluster/slurm.yaml
+++ b/config/cluster/slurm.yaml
@@ -1,0 +1,16 @@
+# @package _global_
+defaults:
+  - override /hydra/launcher: submitit_slurm
+
+hydra:
+  launcher:
+    nodes: ${trainer.num_nodes}
+    gpus_per_node: ${trainer.gpus}
+    tasks_per_node: 1
+    partition: learnfair
+
+hydra:
+  run:
+    dir: /checkpoint/${env:USER}/emg2qwerty/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: /checkpoint/${env:USER}/emg2qwerty/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/config/model/tds_conv_ctc.yaml
+++ b/config/model/tds_conv_ctc.yaml
@@ -1,18 +1,21 @@
 # @package _global_
+optimizer:
+  _target_: torch.optim.Adam
+  lr: 0.001
+
+lr_scheduler:
+  _target_: torch.optim.lr_scheduler.StepLR
+  step_size: 100
+  gamma: 0.1
+
 module:
   _target_: emg2qwerty.train.TDSConvCTCModule
   in_features: 512  # n_mels=32 * channels=16
   out_features: 768
   block_channels: [24, 24, 24, 24]
   kernel_width: 11
-  optimizer:
-    _target_: torch.optim.Adam
-    lr: 0.001
-  lr_scheduler:
-    _target_: torch.optim.lr_scheduler.StepLR
-    step_size: 100
-    gamma: 0.1
-
+  optimizer: ${optimizer}
+  lr_scheduler: ${lr_scheduler}
 
 data_module:
   _target_: emg2qwerty.train.WindowedEmgDataModule

--- a/emg2qwerty/train.py
+++ b/emg2qwerty/train.py
@@ -203,7 +203,7 @@ class TDSConvCTCModule(pl.LightningModule):
 
 @hydra.main(config_path="../config", config_name="base")
 def main(config: DictConfig):
-    print('#### Config Dump ####')
+    print(f'#### Config ####:')
     print(OmegaConf.to_yaml(config))
 
     # Add working dir to PYTHONPATH

--- a/environment.yml
+++ b/environment.yml
@@ -25,4 +25,5 @@ dependencies:
   - pip
   - pip:
     - hydra-core>=1.1.0
+    - hydra-submitit-launcher
     - omegaconf>=2.1.0


### PR DESCRIPTION
Launcher configs for slurm. Use as:
```
python -m emg2qwerty.train user=user0 +cluster=slurm -m
```
Logs and checkpoints will be found at `/checkpoint/${user}/emg2qwerty/`.

To test locally,
```
python -m emg2qwerty.train user=user0 +cluster=local -m
```
Local logs at `./logs/`.

Also switched to `ddp_spawn` from `ddp` since otherwise there appears to be a deadlock when used in conjunction with hydra launcher in the multi-run setting.