### PR TITLE
Remove corrupt datasets from config

### DIFF
--- a/config/user/generic.yaml
+++ b/config/user/generic.yaml
@@ -681,12 +681,8 @@ dataset:
     session: 2021-03-20-1616253893-keystrokes-dca-study@1-8dceb1ff-4d9c-4a90-ab4b-4865f89f6bf4
   - user: d5e4b3b5-4d42-4ec2-87fa-ac0fe1a1a044
     session: 2021-05-09-1620604030-keystrokes-dca-study@1-f6fea34b-8642-4a9d-95fc-6054d9c5c50a
-  - user: 5fc500c0-e43e-4d86-83ca-d56095d15e09
-    session: 2021-05-09-1620603757-keystrokes-dca-study@1-390e43c1-f95d-474e-915f-37f03d2d66e4
   - user: d378e910-f2f1-4989-8269-eb698481b25d
     session: 2021-03-21-1616347488-keystrokes-dca-study@1-22937129-bf9c-490a-8857-354aa10cc963
-  - user: d378e910-f2f1-4989-8269-eb698481b25d
-    session: 2021-03-21-1616344863-keystrokes-dca-study@1-22937129-bf9c-490a-8857-354aa10cc963
   - user: 5fc500c0-e43e-4d86-83ca-d56095d15e09
     session: 2021-05-10-1620662598-keystrokes-dca-study@1-390e43c1-f95d-474e-915f-37f03d2d66e4
   - user: 5fc500c0-e43e-4d86-83ca-d56095d15e09
@@ -1300,8 +1296,6 @@ dataset:
     session: 2020-12-17-1608214211-keystrokes-dca-study@1-a2287ace-5eff-4542-9a53-4de6b48e065c
   - user: 6ea7128c-c448-4304-8c6b-6cec03e5526e
     session: 2021-03-19-1616159532-keystrokes-dca-study@1-16a4fd49-a344-4a75-8453-0811d0b42bd0
-  - user: 6ea7128c-c448-4304-8c6b-6cec03e5526e
-    session: 2021-03-18-1616099637-keystrokes-dca-study@1-16a4fd49-a344-4a75-8453-0811d0b42bd0
   - user: '70495563'
     session: 2020-08-19-1597844765-keystrokes-70495563
   - user: '70495563'


### PR DESCRIPTION
These hdf5 files are corrupt likely due to some upload issues. Removing these for now, but these should get fixed when we regenerate the corpus once DCA collection is complete.

With this, we can now training generic model:
```
python -m emg2qwerty.train user=generic +cluster=slurm -m
```