### PR TITLE
Omegaconf resolver for cpus_per_task

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -39,7 +39,7 @@ hydra:
   run:
     dir: logs/${now:%Y-%m-%d}/${now:%H-%M-%S}
   sweep:
-    dir: logs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    dir: ${hydra.run.dir}
     subdir: ${hydra.job.num}_${hydra.job.override_dirname}
   output_subdir: hydra_configs
   job:

--- a/config/cluster/local.yaml
+++ b/config/cluster/local.yaml
@@ -4,7 +4,8 @@ defaults:
 
 hydra:
   launcher:
-    submitit_folder: ${hydra.sweep.dir}/submitit_logs/%j
+    submitit_folder: ${hydra.run.dir}/submitit_logs/%j
+    timeout_min: 2880
     nodes: ${trainer.num_nodes}
     gpus_per_node: ${trainer.gpus}
     tasks_per_node: 1

--- a/config/cluster/slurm.yaml
+++ b/config/cluster/slurm.yaml
@@ -2,21 +2,15 @@
 defaults:
   - override /hydra/launcher: submitit_slurm
 
-trainer:
-  num_nodes: 1
-  gpus: 8
-
 hydra:
+  run:
+    dir: /checkpoint/${oc.env:USER}/emg2qwerty/${now:%Y-%m-%d}/${now:%H-%M-%S}
   launcher:
-    submitit_folder: ${hydra.sweep.dir}/submitit_logs/%j
+    submitit_folder: ${hydra.run.dir}/submitit_logs/%j
+    timeout_min: 2880
     nodes: ${trainer.num_nodes}
     gpus_per_node: ${trainer.gpus}
     tasks_per_node: 1
-    cpus_per_task: 40
+    cpus_per_task: ${cpus_per_task:${.gpus_per_node},${.tasks_per_node},${num_workers}}
     mem_gb: 300
-    timeout_min: 2880
     partition: learnfair
-  run:
-    dir: /checkpoint/${oc.env:USER}/emg2qwerty/${now:%Y-%m-%d}/${now:%H-%M-%S}
-  sweep:
-    dir: /checkpoint/${oc.env:USER}/emg2qwerty/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/emg2qwerty/train.py
+++ b/emg2qwerty/train.py
@@ -315,4 +315,5 @@ def main(config: DictConfig):
 
 
 if __name__ == "__main__":
+    OmegaConf.register_new_resolver("cpus_per_task", utils.cpus_per_task)
     main()

--- a/emg2qwerty/utils.py
+++ b/emg2qwerty/utils.py
@@ -15,3 +15,11 @@ def instantiate_optimizer_and_scheduler(params: Iterator[nn.Parameter],
         "optimizer": optimizer,
         "lr_scheduler": OmegaConf.to_container(lr_scheduler),
     }
+
+
+def cpus_per_task(gpus_per_node: int, tasks_per_node: int,
+                  num_workers: int) -> int:
+    """Number of CPUs to request per task per node taking into account
+    the number of gpus and dataloading workers."""
+    gpus_per_task = gpus_per_node // tasks_per_node
+    return (num_workers + 1) * gpus_per_task


### PR DESCRIPTION
This avoids needing to specify `hydra.launcher.cpus_per_task` in the cli when `trainer.gpus` change.

With this, to train a generic model:
```
python -m user=generic trainer.gpus=8 +cluster=slurm -m
```

For finetuning personalized models per user:
```
python -m user="glob(user*)" trainer.gpus=1 "checkpoint=</path/to/pretrained/checkpoint.ckpt" +cluster=slurm -m
```