### PR TITLE
Bugfix in RI-MLP and update docs

### DIFF
--- a/config/transforms/log_spectrogram.yaml
+++ b/config/transforms/log_spectrogram.yaml
@@ -1,4 +1,18 @@
 # @package _global_
+to_tensor:
+  _target_: emg2qwerty.transforms.ToTensor
+  fields: [emg_left, emg_right]
+
+band_rotation:
+  _target_: emg2qwerty.transforms.ForEach  # i.i.d rotation offset for each band
+  transform:
+    _target_: emg2qwerty.transforms.RandomBandRotation
+    offsets: [-1, 0, 1]
+
+temporal_jitter:
+  _target_: emg2qwerty.transforms.TemporalAlignmentJitter
+  max_offset: 120  # Max 60ms jitter for 2kHz EMG
+
 logspec:
   _target_: emg2qwerty.transforms.LogSpectrogram
   n_fft: 64
@@ -13,18 +27,14 @@ specaug:
 
 transforms:
   train:
-    - _target_: emg2qwerty.transforms.ToTensor
-      fields: [emg_left, emg_right]
-    - _target_: emg2qwerty.transforms.RandomBandRotation
-      offsets: [-1, 0, 1]
-    - _target_: emg2qwerty.transforms.TemporalAlignmentJitter
-      max_offset: 120  # Max 60ms jitter for 2kHz EMG
+    - ${to_tensor}
+    - ${band_rotation}
+    - ${temporal_jitter}
     - ${logspec}
     - ${specaug}
 
   val:
-    - _target_: emg2qwerty.transforms.ToTensor
-      fields: [emg_left, emg_right]
+    - ${to_tensor}
     - ${logspec}
 
   test: ${transforms.val}

--- a/emg2qwerty/data.py
+++ b/emg2qwerty/data.py
@@ -377,13 +377,33 @@ class LabelData:
 
 @dataclass
 class WindowedEmgDataset(torch.utils.data.Dataset):
-    """TODO: docstring"""
+    """A `torch.utils.data.Dataset` corresponding to an instance of
+    `Emg2QwertySessionData` that iterates over EMG windows of configurable
+    length and stride.
+
+    Args:
+        hdf5_path (str): Path to the session file in hdf5 format.
+        window_length (int): Size of each window. Specify None for no windowing
+            in which case this will be a dataset of length 1 containing the
+            entire session. (default: ``None``)
+        stride (int): Stride between consecutive windows. Specify None to set
+            this to window_length, in which case there will be no overlap
+            between consecutive windows. (default: ``window_length``)
+        padding (Tuple[int, int]): Left and right contextual padding for
+            windows in terms of number of raw EMG samples.
+        jitter (bool): If True, randomly jitter the offset of each window.
+            Use this for training time variability. (default: ``False``)
+        transform (Callable): A composed sequence of transforms that takes
+            a window/slice of `Emg2QwertySessionData` in the form of a numpy
+            structured array and returns a `torch.Tensor` instance.
+            (default: ``emg2qwerty.transforms.ToTensor()``)
+    """
 
     hdf5_path: Path
     window_length: InitVar[Optional[int]] = None
     stride: InitVar[Optional[int]] = None
     padding: InitVar[Tuple[int, int]] = (0, 0)
-    jitter: bool = True
+    jitter: bool = False
     transform: Transform[np.ndarray, torch.Tensor] = transforms.ToTensor()
 
     def __post_init__(

--- a/emg2qwerty/decoder.py
+++ b/emg2qwerty/decoder.py
@@ -175,7 +175,7 @@ class BeamState:
     Args:
         label_node (TrieNode): Reference to the label trie node for this state.
         lm_node (TrieNode): Reference to the LM trie node for this state.
-            (default: None)
+            (default: ``None``)
         p_b (float): Probability (in log-space) of ending in blank.
             We maintain separate probabilities for a decoding ending in blank
             and non-blank to be able to differentiate between repeated tokens
@@ -185,7 +185,7 @@ class BeamState:
             (default: ``-np.inf``)
         hash_ (hashlib._Hash): `hashlib._Hash` object corresponding to this
             state's decoding for efficiently keying the decoded prefix into
-            a dict. (default: None)
+            a dict. (default: ``None``)
     """
 
     label_node: TrieNode
@@ -343,7 +343,7 @@ class CTCBeamDecoder(Decoder):
             scoring labels are considered for the beam update. Otherwise, all
             output labels are considered. (default: -1)
         lm_path (str): Path to optional KenLM n-gram language model file
-            in ARPA or binary format. (default: None)
+            in ARPA or binary format. (default: ``None``)
         lm_weight (float): Weight of the language model scores relative to the
             emission probabilities. (default: 1.2)
         insertion_bonus (float): Character insertion bonus to prevent favoring


### PR DESCRIPTION
Fixes a few bugs:
- RI-MLP rotation was being applied on the wrong dim (freq instead of channel)
- Band rotation aug wasn't iid per band. That is, same rotation offset was being applied for left and right.
- Val dataset had window jitter set which is now disabled.

Additionally, added docs.